### PR TITLE
More MessageDB improvements, including timestamp constraints in getting chatlog (messages since timestamp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Notable changes to OgbujiPT. Format based on [Keep a Changelog](https://keepacha
 ## [Unreleased]
 -->
 
+## [0.7.1] - 20240122
+
+### Added
+
+- MessageDB.get_messages() options: `since` (for retrieving messages aftter a timestamp) and `limit` (for limiting the number of messages returned, selecting the most recent)
+
+### Changed
+
+- Better modularization of embeddings test cases; using `conftest.py` more
+- `pgvector_message.py` PG table timstamp column no longer a primary key
+
 ## [0.7.0] - 20240110
 
 ### Added

--- a/pylib/embedding/pgvector.py
+++ b/pylib/embedding/pgvector.py
@@ -187,7 +187,7 @@ class PGVectorHelper:
             # Count the number of documents in the table
             count = await conn.fetchval(f'SELECT COUNT(*) FROM {self.table_name}')
         return count
-    
+
     async def table_exists(self) -> bool:
         '''
         Check if the table exists
@@ -197,11 +197,11 @@ class PGVectorHelper:
         '''
         # Check if the table exists
         async with (await self.connection_pool()).acquire() as conn:
-            table_exists = await conn.fetchval(
+            exists = await conn.fetchval(
                 CHECK_TABLE_EXISTS,
                 self.table_name
             )
-        return table_exists
+        return exists
 
     async def drop_table(self) -> None:
         '''

--- a/pylib/embedding/pgvector_message.py
+++ b/pylib/embedding/pgvector_message.py
@@ -180,7 +180,7 @@ class MessageDB(PGVectorHelper):
                 )
 
     # XXX: Change to a generator
-    async def get_chatlog(
+    async def get_messages(
             self,
             history_key: UUID | str,
             since: datetime | None = None,
@@ -242,8 +242,8 @@ class MessageDB(PGVectorHelper):
     
     async def get_table(self, history_key):
         # Deprecated
-        warnings.warn('pgvector_message.get_table() is deprecated. Use get_chatlog().', DeprecationWarning)
-        return list(await self.get_chatlog(history_key))
+        warnings.warn('pgvector_message.get_table() is deprecated. Use get_messages().', DeprecationWarning)
+        return list(await self.get_messages(history_key))
 
     async def search(
             self,

--- a/pylib/embedding/pgvector_message.py
+++ b/pylib/embedding/pgvector_message.py
@@ -61,7 +61,7 @@ WHERE
     history_key = $1
 {since_clause}
 ORDER BY
-    ts
+    ts DESC
 {limit_clause};
 '''
 

--- a/test/embedding/test_pgvector_data.py
+++ b/test/embedding/test_pgvector_data.py
@@ -8,16 +8,8 @@ See test/embedding/test_pgvector.py for important notes on running these tests
 import pytest
 from unittest.mock import MagicMock, DEFAULT  # noqa: F401
 
-import os
-from ogbujipt.embedding.pgvector import DataDB
 import numpy as np
 
-# XXX: This stanza to go away once mocking is complete - Kai
-HOST = os.environ.get('PG_HOST', 'localhost')
-DB_NAME = os.environ.get('PG_DATABASE', 'mock_db')
-USER = os.environ.get('PG_USER', 'mock_user')
-PASSWORD = os.environ.get('PG_PASSWORD', 'mock_password')
-PORT = os.environ.get('PG_PORT', 5432)
 
 KG_STATEMENTS = [  # Demo data
     ("👤 Alikiba `releases_single` 💿 'Yalaiti'", {'url': 'https://notjustok.com/lyrics/yalaiti-lyrics-by-alikiba-ft-sabah-salum/'}),
@@ -36,44 +28,24 @@ class SentenceTransformer(object):
 
 
 @pytest.mark.asyncio
-async def test_insert_data_vector():
+async def test_insert_data_vector(DB):
     dummy_model = SentenceTransformer('mock_transformer')
     dummy_model.encode.return_value = np.array([1, 2, 3])
-    TABLE_NAME = 'embedding_data_test'
-    try:
-        vDB = await DataDB.from_conn_params(
-            embedding_model=dummy_model,
-            table_name=TABLE_NAME,
-            db_name=DB_NAME,
-            host=HOST,
-            port=int(PORT),
-            user=USER,
-            password=PASSWORD)
-    except ConnectionRefusedError:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-    if vDB is None:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-
-    # Create tables
-    await vDB.drop_table()
-    assert await vDB.table_exists() is False, Exception("Table exists before creation")
-    await vDB.create_table()
-    assert await vDB.table_exists() is True, Exception("Table does not exist after creation")
 
     item1_text = KG_STATEMENTS[0][0]
     item1_meta = KG_STATEMENTS[0][1]
 
     # Insert data
     for index, (text, meta) in enumerate(KG_STATEMENTS):
-        await vDB.insert(                                  # Insert the row into the table
+        await DB.insert(                                  # Insert the row into the table
             content=text,                                  # text to be embedded
             tags=[f'{k}={v}' for (k, v) in meta.items()],  # Tag metadata
         )
 
-    assert await vDB.count_items() == len(KG_STATEMENTS), Exception('Incorrect number of documents after insertion')
+    assert await DB.count_items() == len(KG_STATEMENTS), Exception('Incorrect number of documents after insertion')
 
     # search table with perfect match
-    result = await vDB.search(text=item1_text, limit=3)
+    result = await DB.search(text=item1_text, limit=3)
     # assert result is not None, Exception('No results returned from perfect search')
 
     # Even though the embedding is mocked, the stored text should be faithful
@@ -81,47 +53,26 @@ async def test_insert_data_vector():
     assert row.content == item1_text
     assert row.tags == [f'{k}={v}' for (k, v) in item1_meta.items()]
 
-    await vDB.drop_table()
+    await DB.drop_table()
 
 
 @pytest.mark.asyncio
-async def test_insertmany_data_vector():
+async def test_insertmany_data_vector(DB):
     dummy_model = SentenceTransformer('mock_transformer')
     dummy_model.encode.return_value = np.array([1, 2, 3])
-    # print(f'EMODEL: {dummy_model}')
-    TABLE_NAME = 'embedding_test'
-    try:
-        vDB = await DataDB.from_conn_params(
-            embedding_model=dummy_model,
-            table_name=TABLE_NAME,
-            db_name=DB_NAME,
-            host=HOST,
-            port=int(PORT),
-            user=USER,
-            password=PASSWORD)
-    except ConnectionRefusedError:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-    if vDB is None:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
 
     item1_text = KG_STATEMENTS[0][0]
     item1_meta = KG_STATEMENTS[0][1]
 
-    # Create tables
-    await vDB.drop_table()
-    assert await vDB.table_exists() is False, Exception("Table exists before creation")
-    await vDB.create_table()
-    assert await vDB.table_exists() is True, Exception("Table does not exist after creation")
-
     # Insert data using insert_many()
     dataset = ((text, [f'{k}={v}' for (k, v) in tags.items()]) for (text, tags) in KG_STATEMENTS)
     
-    await vDB.insert_many(dataset)
+    await DB.insert_many(dataset)
 
-    assert await vDB.count_items() == len(KG_STATEMENTS), Exception('Incorrect number of documents after insertion')
+    assert await DB.count_items() == len(KG_STATEMENTS), Exception('Incorrect number of documents after insertion')
 
     # search table with perfect match
-    result = await vDB.search(text=item1_text, limit=3)
+    result = await DB.search(text=item1_text, limit=3)
     # assert result is not None, Exception('No results returned from perfect search')
 
     # Even though the embedding is mocked, the stored text should be faithful
@@ -129,7 +80,7 @@ async def test_insertmany_data_vector():
     assert row.content == item1_text
     assert row.tags == [f'{k}={v}' for (k, v) in item1_meta.items()]
 
-    await vDB.drop_table()
+    await DB.drop_table()
 
 
 if __name__ == '__main__':

--- a/test/embedding/test_pgvector_doc.py
+++ b/test/embedding/test_pgvector_doc.py
@@ -24,16 +24,8 @@ import pytest
 # from unittest.mock import MagicMock, patch
 from unittest.mock import MagicMock, DEFAULT  # noqa: F401
 
-import os
 from ogbujipt.embedding.pgvector import DocDB
 import numpy as np
-
-# XXX: This stanza to go away once mocking is complete - Kai
-HOST = os.environ.get('PG_HOST', 'localhost')
-DB_NAME = os.environ.get('PG_DATABASE', 'mock_db')
-USER = os.environ.get('PG_USER', 'mock_user')
-PASSWORD = os.environ.get('PG_PASSWORD', 'mock_password')
-PORT = os.environ.get('PG_PORT', 5432)
 
 pacer_copypasta = [  # Demo document
     ('The FitnessGram™ Pacer Test is a multistage aerobic capacity test that progressively gets more difficult as it'
@@ -53,75 +45,31 @@ class SentenceTransformer(object):
 
 
 @pytest.mark.asyncio
-async def test_PGv_embed_pacer():
+async def test_PGv_embed_pacer(DB):
     dummy_model = SentenceTransformer('mock_transformer')
     dummy_model.encode.return_value = np.array([1, 2, 3])
-    # print(f'EMODEL: {dummy_model}')
-    TABLE_NAME = 'embedding_test'
-    try:
-        vDB = await DocDB.from_conn_params(
-            embedding_model=dummy_model,
-            table_name=TABLE_NAME,
-            db_name=DB_NAME,
-            host=HOST,
-            port=int(PORT),
-            user=USER,
-            password=PASSWORD)
-    except ConnectionRefusedError:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-    
-    assert vDB is not None, ConnectionError("Postgres docker instance not available for testing PG code")
-    
-    # Create tables
-    await vDB.drop_table()
-    assert await vDB.table_exists() is False, Exception("Table exists before creation")
-    await vDB.create_table()
-    assert await vDB.table_exists() is True, Exception("Table does not exist after creation")
-
     # Insert data
     for index, text in enumerate(pacer_copypasta):   # For each line in the copypasta
-        await vDB.insert(                            # Insert the line into the table
+        await DB.insert(                            # Insert the line into the table
             content=text,                            # The text to be embedded
             title=f'Pacer Copypasta line {index}',   # Title metadata
             page_numbers=[1, 2, 3],                  # Page number metadata
             tags=['fitness', 'pacer', 'copypasta'],  # Tag metadata
         )
 
-    assert await vDB.count_items() == len(pacer_copypasta), Exception("Not all documents inserted")
+    assert await DB.count_items() == len(pacer_copypasta), Exception("Not all documents inserted")
 
     # search table with perfect match
     search_string = '[beep] A single lap should be completed each time you hear this sound.'
-    sim_search = await vDB.search(text=search_string, limit=3)
+    sim_search = await DB.search(text=search_string, limit=3)
     assert sim_search is not None, Exception("No results returned from perfect search")
 
-    await vDB.drop_table()
+    await DB.drop_table()
 
 @pytest.mark.asyncio
-async def test_PGv_embed_many_pacer():
+async def test_PGv_embed_many_pacer(DB):
     dummy_model = SentenceTransformer('mock_transformer')
     dummy_model.encode.return_value = np.array([1, 2, 3])
-    # print(f'EMODEL: {dummy_model}')
-    TABLE_NAME = 'embedding_test'
-    try:
-        vDB = await DocDB.from_conn_params(
-            embedding_model=dummy_model,
-            table_name=TABLE_NAME,
-            db_name=DB_NAME,
-            host=HOST,
-            port=int(PORT),
-            user=USER,
-            password=PASSWORD)
-    except ConnectionRefusedError:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-    
-    assert vDB is not None, ConnectionError("Postgres docker instance not available for testing PG code")
-    
-    # Create tables
-    await vDB.drop_table()
-    assert await vDB.table_exists() is False, Exception("Table exists before creation")
-    await vDB.create_table()
-    assert await vDB.table_exists() is True, Exception("Table does not exist after creation")
-
     # Insert data using insert_many()
     documents = (
         (
@@ -132,20 +80,20 @@ async def test_PGv_embed_many_pacer():
         )
         for index, text in enumerate(pacer_copypasta)
     )
-    await vDB.insert_many(documents)
+    await DB.insert_many(documents)
 
-    assert await vDB.count_items() == len(pacer_copypasta), Exception("Not all documents inserted")
+    assert await DB.count_items() == len(pacer_copypasta), Exception("Not all documents inserted")
 
     # Search table with perfect match
     search_string = '[beep] A single lap should be completed each time you hear this sound.'
-    sim_search = await vDB.search(text=search_string, limit=3)
+    sim_search = await DB.search(text=search_string, limit=3)
     assert sim_search is not None, Exception("No results returned from perfect search")
 
-    await vDB.drop_table()
+    await DB.drop_table()
 
 
 @pytest.mark.asyncio
-async def test_PGv_search_filtered():
+async def test_PGv_search_filtered(DB):
     dummy_model = SentenceTransformer('mock_transformer')
     def encode_tweaker(*args, **kwargs):
         if args[0].startswith('Text'):
@@ -154,42 +102,22 @@ async def test_PGv_search_filtered():
             return np.array([100, 300, 500])
 
     dummy_model.encode.side_effect = encode_tweaker
-    # print(f'EMODEL: {dummy_model}')
-    TABLE_NAME = 'embedding_test'
-    try:
-        vDB = await DocDB.from_conn_params(
-            embedding_model=dummy_model,
-            table_name=TABLE_NAME,
-            db_name=DB_NAME,
-            host=HOST,
-            port=int(PORT),
-            user=USER,
-            password=PASSWORD)
-    except ConnectionRefusedError:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-    
-    assert vDB is not None, ConnectionError("Postgres docker instance not available for testing PG code")
-    
-    # Create tables
-    await vDB.drop_table()
-    assert await vDB.table_exists() is False, Exception("Table exists before creation")
-    await vDB.create_table()
-    assert await vDB.table_exists() is True, Exception("Table does not exist after creation")
-
+    # Need to replace the default encoder set up by the fixture
+    DB._embedding_model = dummy_model
     # Insert data
     for index, text in enumerate(pacer_copypasta):   # For each line in the copypasta
-        await vDB.insert(                            # Insert the line into the table
+        await DB.insert(                            # Insert the line into the table
             content=text,                            # The text to be embedded
             title='Pacer Copypasta',   # Title metadata
             page_numbers=[index],                    # Page number metadata
             tags=['fitness', 'pacer', 'copypasta'],  # Tag metadata
         )
 
-    assert await vDB.count_items() == len(pacer_copypasta), Exception("Not all documents inserted")
+    assert await DB.count_items() == len(pacer_copypasta), Exception("Not all documents inserted")
 
     # search table with filtered match
     search_string = '[beep] A single lap should be completed each time you hear this sound.'
-    sim_search = await vDB.search(
+    sim_search = await DB.search(
         text=search_string,
         query_title='Pacer Copypasta',
         query_page_numbers=[3],
@@ -199,16 +127,16 @@ async def test_PGv_search_filtered():
     assert sim_search is not None, Exception("No results returned from filtered search")
 
     #Test conjunctive semantics
-    await vDB.insert(content='Text', title='Some text', page_numbers=[1], tags=['tag1'])
-    await vDB.insert(content='Text', title='Some mo text', page_numbers=[1], tags=['tag2', 'tag3'])
-    await vDB.insert(content='Text', title='Even mo text', page_numbers=[1], tags=['tag3'])
+    await DB.insert(content='Text', title='Some text', page_numbers=[1], tags=['tag1'])
+    await DB.insert(content='Text', title='Some mo text', page_numbers=[1], tags=['tag2', 'tag3'])
+    await DB.insert(content='Text', title='Even mo text', page_numbers=[1], tags=['tag3'])
 
     # Using limit default
-    sim_search = await vDB.search(text='Text', tags=['tag1', 'tag3'], conjunctive=False)
+    sim_search = await DB.search(text='Text', tags=['tag1', 'tag3'], conjunctive=False)
     assert sim_search is not None, Exception("No results returned from filtered search")
     assert len(list(sim_search)) == 3, Exception(f"There should be 3 results, received {sim_search}")
 
-    sim_search = await vDB.search(text='Text', tags=['tag1', 'tag3'], conjunctive=False, limit=1000)
+    sim_search = await DB.search(text='Text', tags=['tag1', 'tag3'], conjunctive=False, limit=1000)
     assert sim_search is not None, Exception("No results returned from filtered search")
     assert len(list(sim_search)) == 3, Exception(f"There should be 3 results, received {sim_search}")
 
@@ -217,17 +145,17 @@ async def test_PGv_search_filtered():
     metas = [[f'author={a}'] for a in authors]
     count = len(texts)
     records = zip(texts, metas, ['']*count, [None]*count)
-    await vDB.insert_many(records)
+    await DB.insert_many(records)
 
-    sim_search = await vDB.search(text='Hi there!', threshold=0.999, limit=0)
+    sim_search = await DB.search(text='Hi there!', threshold=0.999, limit=0)
     assert sim_search is not None, Exception("No results returned from filtered search")
     assert len(list(sim_search)) == 3, Exception(f"There should be 3 results, received {sim_search}")
 
-    sim_search = await vDB.search(text='Hi there!', threshold=0.999, limit=2)
+    sim_search = await DB.search(text='Hi there!', threshold=0.999, limit=2)
     assert sim_search is not None, Exception("No results returned from filtered search")
     assert len(list(sim_search)) == 2, Exception(f"There should be 2 results, received {sim_search}")
 
-    await vDB.drop_table()
+    await DB.drop_table()
 
 
 if __name__ == '__main__':

--- a/test/embedding/test_pgvector_doc.py
+++ b/test/embedding/test_pgvector_doc.py
@@ -24,7 +24,7 @@ import pytest
 # from unittest.mock import MagicMock, patch
 from unittest.mock import MagicMock, DEFAULT  # noqa: F401
 
-from ogbujipt.embedding.pgvector import DocDB
+# from ogbujipt.embedding.pgvector import DocDB
 import numpy as np
 
 pacer_copypasta = [  # Demo document

--- a/test/embedding/test_pgvector_message.py
+++ b/test/embedding/test_pgvector_message.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import pytest
 from unittest.mock import MagicMock, DEFAULT  # noqa: F401
 
-import numpy as np
+# import numpy as np
 
 # XXX: Move to a fixture?
 # Definitely don't want to even import SentenceTransformer class due to massive side-effects

--- a/test/embedding/test_pgvector_message.py
+++ b/test/embedding/test_pgvector_message.py
@@ -5,7 +5,6 @@
 See test/embedding/test_pgvector.py for important notes on running these tests
 '''
 
-import os
 from datetime import datetime
 
 import pytest
@@ -13,17 +12,16 @@ from unittest.mock import MagicMock, DEFAULT  # noqa: F401
 
 import numpy as np
 
-from ogbujipt.embedding.pgvector import MessageDB
-
-# XXX: This stanza to go away once mocking is complete - Kai
-HOST = os.environ.get('PG_HOST', 'localhost')
-DB_NAME = os.environ.get('PG_DATABASE', 'mock_db')
-USER = os.environ.get('PG_USER', 'mock_user')
-PASSWORD = os.environ.get('PG_PASSWORD', 'mock_password')
-PORT = os.environ.get('PG_PORT', 5432)
+# XXX: Move to a fixture?
+# Definitely don't want to even import SentenceTransformer class due to massive side-effects
+class SentenceTransformer(object):
+    def __init__(self, model_name_or_path):
+        self.encode = MagicMock()
 
 
-MESSAGES = [  # Test data: history_key, role, content, timestamp, metadata
+@pytest.fixture
+def MESSAGES():
+    messages = [  # Test data: history_key, role, content, timestamp, metadata
     ('00000000-0000-0000-0000-000000000000', 'ama', 'Hello Eme!', '2021-10-01 00:00:00+00:00', {'1': 'a'}),
     ('00000000-0000-0000-0000-000000000001', 'ugo', 'Greetings Ego', '2021-10-01 00:00:01+00:00', {'2': 'b'}),
     ('00000000-0000-0000-0000-000000000000', 'eme', 'How you dey, Ama!', '2021-10-01 00:00:02+00:00', {'3': 'c'}),
@@ -33,98 +31,42 @@ MESSAGES = [  # Test data: history_key, role, content, timestamp, metadata
     ('00000000-0000-0000-0000-000000000000', 'eme', 'Very good. Say hello to your family for me.', '2021-10-01 00:00:06+00:00', {'7': 'g'}),  # noqa: E501
     ('00000000-0000-0000-0000-000000000001', 'ugo', 'An even better surprise, I hope!', '2021-10-01 00:00:07+00:00', {'8': 'h'})  # noqa: E501
     ]
-MESSAGES = [
-    (history_key, role, content, datetime.fromisoformat(timestamp), metadata)
-    for history_key, role, content, timestamp, metadata in MESSAGES
-]
-
-
-# XXX: Move to a fixture?
-# Definitely don't want to even import SentenceTransformer class due to massive side-effects
-class SentenceTransformer(object):
-    def __init__(self, model_name_or_path):
-        self.encode = MagicMock()
+    return [(history_key, role, content, datetime.fromisoformat(timestamp), metadata)
+    for history_key, role, content, timestamp, metadata in messages
+    ]
 
 
 @pytest.mark.asyncio
-async def test_insert_message_vector():
-    dummy_model = SentenceTransformer('mock_transformer')
-    dummy_model.encode.return_value = np.array([1, 2, 3])
-    TABLE_NAME = 'embedding_msg_test'
-    try:
-        vDB = await MessageDB.from_conn_params(
-            embedding_model=dummy_model,
-            table_name=TABLE_NAME,
-            db_name=DB_NAME,
-            host=HOST,
-            port=int(PORT),
-            user=USER,
-            password=PASSWORD)
-    except ConnectionRefusedError:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-    if vDB is None:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-
-    # Create tables
-    await vDB.drop_table()
-    assert await vDB.table_exists() is False, Exception("Table exists before creation")
-    await vDB.create_table()
-    assert await vDB.table_exists() is True, Exception("Table does not exist after creation")
-
+async def test_insert_message_vector(DB, MESSAGES):
     # Insert data
     for index, (row) in enumerate(MESSAGES):
-        await vDB.insert(*row)
+        await DB.insert(*row)
 
-    assert await vDB.count_items() == len(MESSAGES), Exception('Incorrect number of messages after insertion')
+    assert await DB.count_items() == len(MESSAGES), Exception('Incorrect number of messages after insertion')
 
     history_key, role, content, timestamp, metadata = MESSAGES[0]
 
     # search table with perfect match
-    result = await vDB.search(text=content, history_key=history_key, limit=3)
+    result = await DB.search(text=content, history_key=history_key, limit=3)
     # assert result is not None, Exception('No results returned from perfect search')
 
     # Even though the embedding is mocked, the stored text should be faithful
     row = next(result)
     assert row.content == content
     assert row.metadata == {'1': 'a'}
-
-    await vDB.drop_table()
 
 
 @pytest.mark.asyncio
-async def test_insertmany_message_vector():
-    dummy_model = SentenceTransformer('mock_transformer')
-    dummy_model.encode.return_value = np.array([1, 2, 3])
-    TABLE_NAME = 'embedding_msg_test'
-    try:
-        vDB = await MessageDB.from_conn_params(
-            embedding_model=dummy_model,
-            table_name=TABLE_NAME,
-            db_name=DB_NAME,
-            host=HOST,
-            port=int(PORT),
-            user=USER,
-            password=PASSWORD)
-    except ConnectionRefusedError:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-    if vDB is None:
-        pytest.skip("No Postgres instance made available for test. Skipping.", allow_module_level=True)
-
-    # Create tables
-    await vDB.drop_table()
-    assert await vDB.table_exists() is False, Exception("Table exists before creation")
-    await vDB.create_table()
-    assert await vDB.table_exists() is True, Exception("Table does not exist after creation")
-
+async def test_insertmany_message_vector(DB, MESSAGES):
     # Insert data using insert_many()
-    await vDB.insert_many(MESSAGES)
+    await DB.insert_many(MESSAGES)
 
-    assert await vDB.count_items() == len(MESSAGES), Exception('Incorrect number of messages after insertion')
+    assert await DB.count_items() == len(MESSAGES), Exception('Incorrect number of messages after insertion')
 
     history_key, role, content, timestamp, metadata = MESSAGES[0]
 
     # search table with perfect match
-    result = await vDB.search(text=content, history_key=history_key, limit=3)
+    result = await DB.search(text=content, history_key=history_key, limit=3)
     # assert result is not None, Exception('No results returned from perfect search')
 
     # Even though the embedding is mocked, the stored text should be faithful
@@ -132,8 +74,34 @@ async def test_insertmany_message_vector():
     assert row.content == content
     assert row.metadata == {'1': 'a'}
 
-    await vDB.drop_table()
 
+@pytest.mark.asyncio
+async def test_get_chatlog_all_limit(DB, MESSAGES):
+    # Insert data using insert_many()
+    await DB.insert_many(MESSAGES)
+
+    history_key, role, content, timestamp, metadata = MESSAGES[0]
+
+    results = await DB.get_chatlog(history_key=history_key)
+    assert len(list(results)) == 4, Exception('Incorrect number of messages returned from chatlog')
+
+    results = await DB.get_chatlog(history_key=history_key, limit=3)
+    assert len(list(results)) == 3, Exception('Incorrect number of messages returned from chatlog')
+
+
+@pytest.mark.asyncio
+async def test_get_chatlog_since(DB, MESSAGES):
+    await DB.insert_many(MESSAGES)
+
+    history_key, role, content, timestamp, metadata = MESSAGES[0]
+
+    since_ts = datetime.fromisoformat('2021-10-01 00:00:03+00:00')
+    results = list(await DB.get_chatlog(history_key=history_key, since=since_ts))
+    assert len(results) == 2, Exception('Incorrect number of messages returned from chatlog')
+
+    since_ts = datetime.fromisoformat('2021-10-01 00:00:04+00:00')
+    results = list(await DB.get_chatlog(history_key=history_key, since=since_ts))
+    assert len(results) == 1, Exception('Incorrect number of messages returned from chatlog')
 
 if __name__ == '__main__':
     raise SystemExit("Attention! Run with pytest")

--- a/test/embedding/test_pgvector_message.py
+++ b/test/embedding/test_pgvector_message.py
@@ -88,6 +88,13 @@ async def test_get_messages_all_limit(DB, MESSAGES):
     results = await DB.get_messages(history_key=history_key, limit=3)
     assert len(list(results)) == 3, Exception('Incorrect number of messages returned from chatlog')
 
+    # With limit, should return the most recent messages
+    history_key, role, content, timestamp, metadata = MESSAGES[-1]
+
+    results = list(await DB.get_messages(history_key=history_key, limit=1))
+    assert len(results) == 1, Exception('Incorrect number of messages returned from chatlog')
+    assert results[0].content == content, Exception('Incorrect message returned from chatlog')
+
 
 @pytest.mark.asyncio
 async def test_get_messages_since(DB, MESSAGES):
@@ -102,6 +109,7 @@ async def test_get_messages_since(DB, MESSAGES):
     since_ts = datetime.fromisoformat('2021-10-01 00:00:04+00:00')
     results = list(await DB.get_messages(history_key=history_key, since=since_ts))
     assert len(results) == 1, Exception('Incorrect number of messages returned from chatlog')
+
 
 if __name__ == '__main__':
     raise SystemExit("Attention! Run with pytest")

--- a/test/embedding/test_pgvector_message.py
+++ b/test/embedding/test_pgvector_message.py
@@ -76,31 +76,31 @@ async def test_insertmany_message_vector(DB, MESSAGES):
 
 
 @pytest.mark.asyncio
-async def test_get_chatlog_all_limit(DB, MESSAGES):
+async def test_get_messages_all_limit(DB, MESSAGES):
     # Insert data using insert_many()
     await DB.insert_many(MESSAGES)
 
     history_key, role, content, timestamp, metadata = MESSAGES[0]
 
-    results = await DB.get_chatlog(history_key=history_key)
+    results = await DB.get_messages(history_key=history_key)
     assert len(list(results)) == 4, Exception('Incorrect number of messages returned from chatlog')
 
-    results = await DB.get_chatlog(history_key=history_key, limit=3)
+    results = await DB.get_messages(history_key=history_key, limit=3)
     assert len(list(results)) == 3, Exception('Incorrect number of messages returned from chatlog')
 
 
 @pytest.mark.asyncio
-async def test_get_chatlog_since(DB, MESSAGES):
+async def test_get_messages_since(DB, MESSAGES):
     await DB.insert_many(MESSAGES)
 
     history_key, role, content, timestamp, metadata = MESSAGES[0]
 
     since_ts = datetime.fromisoformat('2021-10-01 00:00:03+00:00')
-    results = list(await DB.get_chatlog(history_key=history_key, since=since_ts))
+    results = list(await DB.get_messages(history_key=history_key, since=since_ts))
     assert len(results) == 2, Exception('Incorrect number of messages returned from chatlog')
 
     since_ts = datetime.fromisoformat('2021-10-01 00:00:04+00:00')
-    results = list(await DB.get_chatlog(history_key=history_key, since=since_ts))
+    results = list(await DB.get_messages(history_key=history_key, since=since_ts))
     assert len(results) == 1, Exception('Incorrect number of messages returned from chatlog')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement `pgvector_message.get_chatlog()`, with support for date constraint & limit,  while deprecating `pgvector_message.get_table()`. Tidy up embedding tests with more use of fixtures & teardown.