### PR TITLE
Add model styles w/out BOS

### DIFF
--- a/pylib/prompting/model_style.py
+++ b/pylib/prompting/model_style.py
@@ -102,6 +102,11 @@ MISTRAL_INSTRUCTION_DELIMITERS = {
     pdelim.POST_ALL_CONTEXT: '\n[/INST]',
 }
 
+MISTRAL_INSTRUCTION_DELIMITERS_NO_BOS = {
+    pdelim.PRE_ALL_CONTEXT: '[INST]',
+    pdelim.POST_ALL_CONTEXT: '\n[/INST]',
+}
+
 CHATML_DELIMITERS = {
     pdelim.PRE_PREAMBLE: '<|im_start|>system\n',
     pdelim.PREQUERY: '<|im_end|>\n<|im_start|>user\n',


### PR DESCRIPTION
When doing low-level finetuning (without the aid of HF's [SFTtrainer](https://huggingface.co/docs/trl/sft_trainer) library, for example), you may need to be able to tokenize a string with the model's prompting format but without special characters (BOS and EOS).  Mistral is the only model format in model_style.py with a distinct BOS character separate from other delimiters (such as <|im_start|> for chatml, which is not really a BOS but a structured delimiter).  So, I added a template without the '<s>' BOS character.  

In any case, BOS characters would usually be added by the tokenizer before the prompt is fed to the model and would, therefore, happen downstream from OgbujiPT.