### PR TITLE
[#30] text splitter enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,35 @@
 Notable changes to  Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!--
--->
 ## [Unreleased]
 
+-->
+
+## [0.9.0] - 20240604
+
+### Added
+
+- `text_helper.text_split_fuzzy()` as basically a generator version of `text_helper.text_splitter()`, and deprecate the latter
+- `text_helper.text_split()` which brooks no overlap
+- `embedding.pgvector_data` module for vector database embedding of data fields using PGVector. Document fields are now treated as simple text, with specialized metadata generalized in the new `metadata` field
+- query filter mix-in, `embedding.pgvector.match_exact()`, for filtering vector search by metadata fields via new `meta_filter` argument to DB.search. This restores some of the tag matching search functionality that's been removed.
+- `clone()` method on `wordloom.language_item` class (formerly `text_item`)
+- `meta` and `preserve_key` args on `wordloom.language_item` (formerly `text_item`) initializer, to preserve TOML table items and top-level TOML key for each language item, respectively, in object properties
+
+### Changed
+
+- Deprecation of `text_helper.text_splitter()`
+- `tags` field of table encapsulated in `embedding.pgvector_data` now modified into a general, JSON `meta` field
+- Word Loom now uses `_` as the TOML table key for text content. The former `text` is deprecated
+- Word Loom now uses `_m` as the TOML table key for text substitution markers. The former `markers` is deprecated
+- Word Loom now reserves TOML table keys beginning with `_`, and passes on all other keys to the new `meta` property
+- `wordloom.text_item` class now renamed `wordloom.language_item`
+- `lang` arg on `wordloom.language_item` (formerly `text_item`) initializer renamed `deflang`
+
+### Removed
+
+- `embedding.pgvector_data_doc` (now just `embedding.pgvector_data`)
+- `conjunctive` option for tags searching now removed, in favor of a query filter mix-in approach
 
 ## [0.8.0] - 20240325
 

--- a/pylib/__about__.py
+++ b/pylib/__about__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 # ogbujipt.about
 
-__version__ = "0.8.0"
+__version__ = '0.8.1'

--- a/pylib/text_helper.py
+++ b/pylib/text_helper.py
@@ -9,25 +9,85 @@ import re
 import warnings
 
 
-def text_splitter(text: str,
+def text_split(text: str, chunk_size: int, separator: str='\n\n', len_func=len) -> list[str]:
+    '''
+    Split string and generate the sequence of chunks
+
+    >>> from ogbujipt.text_helper import text_split
+    >>> list(text_split('She sells seashells by the seashore', chunk_size=5, separator=' '))
+    ['She', 'sells', 'seashells', 'by', 'the', 'seashore']
+    >>> list(text_split('She sells seashells by the seashore', chunk_size=10, separator=' '))
+    ['She sells', 'seashells', 'by the', 'seashore']
+    # Notice case sensitivity, plus the fact that the separator is not included in the chunks
+    >>> list(text_split('She sells seashells by the seashore', chunk_size=10, separator='s'))
+    ['She ', 'ells ', 'ea', 'hell', ' by the ', 'ea', 'hore']
+
+    Args:
+        text (str): String to be split into chunks
+
+        chunk_size (int): Guidance on maximum length (based on distance_function) of each chunk
+
+        seperator (str, optional): String that already splits "text" into sections
+
+        distance_function (callable, optional): Function to measure length, len() by default
+
+    Returns:
+        chunks (List[str]): List of chunks of the text provided
+    '''
+    assert separator, 'Separator must be non-empty'
+    
+    if ((not isinstance(text, str))
+        or (not isinstance(separator, str))):
+        raise ValueError(f'text and separator must be strings.\n'
+                         f'Got {text.__class__} for text and {separator.__class__} for separator')
+    
+    if ((not isinstance(chunk_size, int)) or (chunk_size <= 0)):
+        raise ValueError(f'chunk_size must be a positive integer, got {chunk_size}.')
+    
+    # Split up the text by the separator
+    # FIXME: Need a step for escaping regex
+    sep_pat = re.compile(separator)
+    fine_split = re.split(sep_pat, text)
+    separator_len = len_func(separator)
+
+    if len(fine_split) <= 1:
+        warnings.warn(f'No splits detected. Perhaps a problem with separator? ({repr(separator)})?')
+
+    curr_chunk = []
+    chunk_len = 0
+
+    for fs in fine_split:
+        if not fs: continue  # noqa E701
+        print(fs)
+        len_fs = len_func(fs)
+        # if len_fs > chunk_size:
+        #     warnings.warn(f'One of the splits is larger than the chunk size. '
+        #                   f'Consider increasing the chunk size or splitting the text differently.')
+
+        if chunk_len + len_fs + separator_len > chunk_size:
+            yield separator.join(curr_chunk)
+            curr_chunk, chunk_len = [fs], len_fs
+        else:
+            curr_chunk.append(fs)
+            chunk_len += len_fs + separator_len
+
+    if curr_chunk:
+        yield separator.join(curr_chunk)
+
+
+def text_split_fuzzy(text: str,
         chunk_size: int,
         chunk_overlap: int=0,
         separator: str='\n\n',
         len_func=len
     ) -> list[str]:
     '''
-    Split string into a set of chunks
-
-    Note that this function is "fuzzy"; it will not necessarily split the text into perfectly chunk_size length chunks, 
-    and will preserve items between the given separators. this results in slightly larger chunks than requested.
-
-    Much like langchain's CharTextSplitter.py
+    Split string into a sequence of chunks in a "fuzzy" manner. Will generally not split the text into sequences
+    of chunk_size length, but will instead preserve some overlap on either side of the given separators.
+    This results in slightly larger chunks than the chunk_size number by itself suggests.
 
     >>> from ogbujipt.text_helper import text_splitter
-    >>> from PyPDF2 import PdfReader
-    >>> pdf_reader = PdfReader('monopoly-board-game-manual.pdf')
-    >>> text = ''.join((page.extract_text() for page in pdf_reader.pages))
-    >>> chunks = text_splitter(text, chunk_size=500, separator='\n')
+    >>> chunks = text_split_fuzzy('she sells seashells by the seashore', chunk_size=50, separator=' ')
 
     Args:
         text (str): (Multiline) String to be split into chunks
@@ -50,6 +110,10 @@ def text_splitter(text: str,
         raise ValueError(f'text and separator must be strings.\n'
                          f'Got {text.__class__} for text and {separator.__class__} for separator')
     
+    if chunk_overlap == 0:
+        msg = 'chunk_overlap must be a positive integer. For no overlap, use text_split() instead'
+        raise ValueError(msg)
+
     if ((not isinstance(chunk_size, int))
         or (not isinstance(chunk_overlap, int))
         or (chunk_size <= 0)
@@ -67,11 +131,135 @@ def text_splitter(text: str,
     separator_len = len_func(separator)
 
     if len(fine_split) <= 1:
-        warnings.warn(f'No splits detected. Problem with separator ({repr(separator)})?')
+        warnings.warn(f'No splits detected. Perhaps a problem with separator? ({repr(separator)})?')
 
-    # Combine the small pieces into medium size chunks to send to LLM
-    # Initialize accumulators; chunks will be the target list of the chunks so far
-    # curr_chunk will be a list of parts comprising the main, current chunk
+    # Combine the small pieces into medium size chunks
+    # chunks will accumulate processed text chunks as we go along
+    # curr_chunk will be a list of subchunks comprising the main, current chunk
+    # back_overlap will be appended, once ready, to the end of the previous chunk (if any)
+    # fwd_overlap will be prepended, once ready, to the start of the next chunk
+    chunks = []
+    curr_chunk, curr_chunk_len = [], 0
+    back_overlap, back_overlap_len = None, 0  # None signals not yet gathering
+    fwd_overlap, fwd_overlap_len = None, 0
+
+    for s in fine_split:
+        if not s: continue  # noqa E701
+        split_len = len_func(s) + separator_len
+        # Check for full back_overlap (if relevant, i.e. back_overlap isn't None)
+        if back_overlap is not None and (back_overlap_len + split_len > chunk_overlap):  # noqa: F821
+            chunks[-1].extend(back_overlap)
+            back_overlap, back_overlap_len = None, 0
+
+        # Will adding this split take us into overlap room?
+        if curr_chunk_len + split_len > (chunk_size - chunk_overlap):
+            fwd_overlap, fwd_overlap_len = [], 0  # Start gathering
+
+        # Will adding this split take us over chunk size?
+        if curr_chunk_len + split_len > chunk_size:
+            # If so, complete current chunk & start a new one
+
+            # fwd_overlap should be non-None at this point, so check empty
+            if not fwd_overlap and curr_chunk:
+                # If empty, look back to make sure there is some overlap
+                fwd_overlap.append(curr_chunk[-1])
+
+            chunks.append(curr_chunk)
+            # fwd_overlap intentionally not counted in running chunk length
+            curr_chunk, curr_chunk_len = fwd_overlap, 0
+            back_overlap, back_overlap_len = [], 0  # Start gathering
+            fwd_overlap, fwd_overlap_len = None, 0  # Stop gathering
+
+        if fwd_overlap is not None:
+            fwd_overlap.append(s)
+            fwd_overlap_len += split_len
+
+        if back_overlap is not None:
+            back_overlap.append(s)
+            back_overlap_len += split_len
+
+        curr_chunk.append(s)
+        curr_chunk_len += split_len
+
+    # Done with the splits; use the final back_overlap, if any
+    if back_overlap:
+        chunks[-1].extend(back_overlap)
+
+    # Concatenate all the split parts of all the chunks
+    chunks = [separator.join(c) for c in chunks]
+
+    # Handle degenerate case where no splits found & chunk size too large
+    # Just becomes one big chunk
+    if not chunks:
+        chunks = [text]
+
+    # chunks.append(separator.join(curr_chunk))
+    return chunks
+
+
+def text_splitter(text: str,
+        chunk_size: int,
+        chunk_overlap: int=0,
+        separator: str='\n\n',
+        len_func=len
+    ) -> list[str]:
+    '''
+    Split string into a sequence of chunks in a "fuzzy" manner. Will generally not split the text into sequences
+    of chunk_size length, but will instead preserve some overlap on either side of the given separators.
+    This results in slightly larger chunks than the chunk_size number by itself suggests.
+
+    >>> from ogbujipt.text_helper import text_splitter
+    >>> chunks = text_split_fuzzy('she sells seashells by the seashore', chunk_size=50, separator=' ')
+
+    Args:
+        text (str): (Multiline) String to be split into chunks
+
+        chunk_size (int): Number of characters to include per chunk
+
+        chunk_overlap (int, optional): Number of characters to overlap at the edges of chunks
+
+        seperator (str, optional): String that already splits "text" into sections
+
+        distance_function (callable, optional): Function to measure length, len() by default
+
+    Returns:
+        chunks (List[str]): List of chunks of the text provided
+    '''
+    warnings.warn('text_splitter() is deprecated. Use text_split_fuzzy() instead.')
+
+    assert separator, 'Separator must be non-empty'
+    
+    if ((not isinstance(text, str))
+        or (not isinstance(separator, str))):
+        raise ValueError(f'text and separator must be strings.\n'
+                         f'Got {text.__class__} for text and {separator.__class__} for separator')
+    
+    if chunk_overlap == 0:
+        msg = 'chunk_overlap must be a positive integer. For no overlap, use text_split() instead'
+        raise ValueError(msg)
+
+    if ((not isinstance(chunk_size, int))
+        or (not isinstance(chunk_overlap, int))
+        or (chunk_size <= 0)
+        or (chunk_overlap < 0)
+        or (chunk_size < chunk_overlap)):
+        raise ValueError(f'chunk_size must be a positive integer, '
+                         f'chunk_overlap must be a non-negative integer, and'
+                         f'chunk_size must be greater than chunk_overlap.\n'
+                         f'Got {chunk_size} chunk_size and {chunk_overlap} chunk_overlap.')
+    
+    # Split up the text by the separator
+    # FIXME: Need a step for escaping regex
+    sep_pat = re.compile(separator)
+    fine_split = re.split(sep_pat, text)
+    separator_len = len_func(separator)
+
+    if len(fine_split) <= 1:
+        warnings.warn(f'No splits detected. Perhaps a problem with separator? ({repr(separator)})?')
+
+    # Combine the small pieces into medium size chunks
+    # chunks will accumulate processed text chunks as we go along
+    # curr_chunk will be a list of subchunks comprising the main, current chunk
     # back_overlap will be appended, once ready, to the end of the previous chunk (if any)
     # fwd_overlap will be prepended, once ready, to the start of the next chunk
     chunks = []

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,7 +102,7 @@ klmnopqrst'''
 def LOREM_IPSUM():
     # Lorem ipsum text
     return (
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vestibulum nisl eget mauris malesuada, '
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vestibulum nisi eget mauris malesuada, '
         'quis facilisis arcu vehicula. Sed consequat, quam ut auctor volutpat, augue ex tincidunt massa, in varius '
         'nulla ex vel ipsum. Nullam vitae eros nec ante sagittis luctus. Nullam scelerisque dolor eu orci iaculis, '
         'at convallis nulla luctus. Praesent eget ex id arcu facilisis varius vel id neque. Donec non orci eget '

--- a/test/test_text_splitter.py
+++ b/test/test_text_splitter.py
@@ -12,16 +12,16 @@ pytest test/test_text_splitter.py
 
 import pytest
 
-from ogbujipt.text_helper import text_splitter
+from ogbujipt.text_helper import text_split, text_split_fuzzy
 
 # Also test: chunk_overlap > chunk_size, chunk_overlap == chunk_size, etc.
 
 
 def test_split_basic(BASIC_EVEN_BLOCK):
     # Need to test chunk_size > total length
-    # chunks = text_splitter(BASIC_EVEN_BLOCK, chunk_size=100, chunk_overlap=10)
-    chunks = text_splitter(
-        BASIC_EVEN_BLOCK, chunk_size=21, chunk_overlap=3, separator='\n')
+    # chunks = text_split_fuzzy(BASIC_EVEN_BLOCK, chunk_size=100, chunk_overlap=10)
+    chunks = list(text_split_fuzzy(
+        BASIC_EVEN_BLOCK, chunk_size=21, chunk_overlap=3, separator='\n'))
     # import pprint; pprint.pprint(chunks)  # noqa
     assert len(chunks) == 3
     assert chunks == [
@@ -34,7 +34,7 @@ def test_split_basic(BASIC_EVEN_BLOCK):
 def test_split_poem(COME_THUNDER_POEM):
     # Just use a subset of the poem
     poem_text = COME_THUNDER_POEM.partition('The arrows of God')[0]
-    chunks = text_splitter(poem_text, chunk_size=200, chunk_overlap=30)
+    chunks = list(text_split_fuzzy(poem_text, chunk_size=200, chunk_overlap=30))
     # print(chunks[0], '\n---')
     assert chunks[0] == 'Now that the triumphant march has entered the last street corners,\nRemember, O dancers, the thunder among the clouds…\n\nNow that the laughter, broken in two, hangs tremulous between the teeth,\nRemember, O Dancers, the lightning beyond the earth…'
     assert chunks[1] == 'Now that the triumphant march has entered the last street corners,\nRemember, O dancers, the thunder among the clouds…\n\nNow that the laughter, broken in two, hangs tremulous between the teeth,\nRemember, O Dancers, the lightning beyond the earth…\n\nThe smell of blood already floats in the lavender-mist of the afternoon.\nThe death sentence lies in ambush along the corridors of power;\nAnd a great fearful thing already tugs at the cables of the open air,\nA nebula immense and immeasurable, a night of deep waters —\nAn iron dream unnamed and unprintable, a path of stone.'
@@ -45,8 +45,8 @@ def test_split_poem(COME_THUNDER_POEM):
 
 def test_separator_not_found(BASIC_EVEN_BLOCK):
     with pytest.warns(UserWarning):
-        chunks = text_splitter(
-            BASIC_EVEN_BLOCK, chunk_size=21, chunk_overlap=3, separator='!!!')
+        chunks = list(text_split_fuzzy(
+            BASIC_EVEN_BLOCK, chunk_size=21, chunk_overlap=3, separator='!!!'))
     assert len(chunks) == 1
     assert len(chunks[0]) == len(BASIC_EVEN_BLOCK)
 
@@ -54,24 +54,18 @@ def test_separator_not_found(BASIC_EVEN_BLOCK):
 def test_separator_chunk_size_too_large(BASIC_EVEN_BLOCK):
     # Just use a subset of the poem
     with pytest.warns(UserWarning):
-        chunks = text_splitter(
-            BASIC_EVEN_BLOCK, chunk_size=100, chunk_overlap=10, separator='!!!')
+        chunks = list(text_split_fuzzy(
+            BASIC_EVEN_BLOCK, chunk_size=100, chunk_overlap=10, separator='!!!'))
     assert len(chunks) == 1
     assert len(chunks[0]) == len(BASIC_EVEN_BLOCK)
 
-# def test_zero_overlap(LOREM_IPSUM):
-#     chunks = text_splitter(LOREM_IPSUM, chunk_size=100, chunk_overlap=0, separator=' ')
-#     assert len(chunks) == 9
-#     # chunks should end on the word that takes it over the chunk size
-#     assert chunks[0] == 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vestibulum nisl eget mauris malesuada,'
-#     assert chunks[1] == 'quis facilisis arcu vehicula. Sed consequat, quam ut auctor volutpat, augue ex tincidunt massa, in varius'
-#     assert chunks[2] == 'nulla ex vel ipsum. Nullam vitae eros nec ante sagittis luctus. Nullam scelerisque dolor eu orci iaculis,'
-#     assert chunks[3] == 'at convallis nulla luctus. Praesent eget ex id arcu facilisis varius vel id neque. Donec non orci eget'
-#     assert chunks[4] == 'elit aliquam tempus. Sed at tortor at tortor congue dictum. Nulla varius erat at libero lacinia, id dignissim'
-#     assert chunks[5] == 'risus auctor. Ut eu odio vehicula, tincidunt justo ac, viverra erat. Sed nec sem sit amet erat malesuada'
-#     assert chunks[6] == 'finibus. Nulla sit amet diam nec dolor tristique dignissim. Sed vehicula, justo nec posuere eleifend,'
-#     assert chunks[7] == 'libero ligula interdum neque, at lacinia arcu quam non est. Integer aliquet, erat id dictum euismod, felis'
-#     assert chunks[8] == 'libero blandit lorem, nec ullamcorper quam justo at elit.'
+def test_zero_overlap(LOREM_IPSUM):
+    chunks = list(text_split(LOREM_IPSUM, chunk_size=100, separator=' '))
+    assert len(chunks) == 10
+    assert chunks[0] == 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vestibulum nisi eget mauris'
+    assert chunks[2] == 'massa, in varius nulla ex vel ipsum. Nullam vitae eros nec ante sagittis luctus. Nullam scelerisque'
+    assert chunks[3] == 'dolor eu orci iaculis, at convallis nulla luctus. Praesent eget ex id arcu facilisis varius vel id'
+    assert chunks[-1] == 'elit.'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Create `text_helper.text_split_fuzzy()` as basically a generator version of `text_helper.text_splitter()`, and deprecate the latter
* Create `text_helper.text_split()` which brooks no overlap
